### PR TITLE
Temp fix for Browse Song page explosion

### DIFF
--- a/models/song.php
+++ b/models/song.php
@@ -29,7 +29,7 @@ class Song extends Model {
       $key = $this->key;
     }
     
-    if ($key === null) {
+    if ($key === null || $key === 'auto') {
       return '';
     }
 


### PR DESCRIPTION
Browse Song page is broken due to a bad database entry. Don't know how the bad entry happened or how to fix, this is a stopgap.
