### PR TITLE
Fixes #17: Song's key was saved as "auto" (text)

### DIFF
--- a/models/song.php
+++ b/models/song.php
@@ -16,7 +16,8 @@ class Song extends Model {
       $this->has_chords = $s->hasChords;
       $this->key = $s->originalKey()->value();
     } else {
-      $this->has_chords = false;
+      // User should not be able to save empty song
+      return false;
     }
 
     //$this->saveFullTextCopy();


### PR DESCRIPTION
Fixes #17 
This only happens when user tries to save a song with empty lyrics. User shouldn't be able to do that.

This commit also undo previous quick fix.
