### PR TITLE
Fix setlists with special characters

### DIFF
--- a/models/setlist.php
+++ b/models/setlist.php
@@ -71,7 +71,7 @@ class Setlist extends Model {
   }
 
   public function pdfName() {
-    return preg_replace('/^-+|-+$/', "", preg_replace('/-+/', "-", preg_replace('/[_|\s]+/', "-", strtolower($this->title)))).'.pdf';
+    return preg_replace('/^-+|-+$/', "", preg_replace('/-+/', "-", preg_replace('/[#|\?|\/|\\\|_|\s]+/', "-", strtolower($this->title)))).'.pdf';
   }
   
   public function pdfOutput($songs = array(), $settings = array()) {


### PR DESCRIPTION
Fixes #26

Setlists failed to download when having special characters like `?`, `#`, `/`, `\`